### PR TITLE
Link 'View Vulcan Range' button to gallery modal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import { Reviews } from "@/components/reviews"
 export default function HomePage() {
   const [videoModalOpen, setVideoModalOpen] = useState(false)
   const [picturesModalOpen, setPicturesModalOpen] = useState(false)
+  const [isVulcanGalleryOpen, setIsVulcanGalleryOpen] = useState(false)
   const [isLoaded, setIsLoaded] = useState(false)
   const [scrollY, setScrollY] = useState(0)
   const observerRef = useRef<IntersectionObserver | null>(null)
@@ -235,11 +236,12 @@ export default function HomePage() {
                     beautifully as they look. Superior acoustic performance. Custom visual designs.
                   </p>
                 </div>
-                <a href="#vulcan-range">
-                  <Button className="btn-secondary magnetic-hover shimmer-effect fluid-animate opacity-0 translate-y-[20px] stagger-4 transition-all duration-400">
-                    View Vulcan Range
-                  </Button>
-                </a>
+                <Button
+                  onClick={() => setIsVulcanGalleryOpen(true)}
+                  className="btn-secondary magnetic-hover shimmer-effect fluid-animate opacity-0 translate-y-[20px] stagger-4 transition-all duration-400"
+                >
+                  View Vulcan Range
+                </Button>
               </div>
               <div className="relative cascade-animate opacity-0 translate-x-[60px]">
                 <div className="professional-card p-4 rounded-2xl magnetic-hover transition-all duration-500">
@@ -257,7 +259,10 @@ export default function HomePage() {
         
 
         <div className="fluid-animate opacity-0 translate-y-[50px]">
-          <WallSystemsShowcase />
+          <WallSystemsShowcase
+            externalIsVulcanGalleryOpen={isVulcanGalleryOpen}
+            setExternalIsVulcanGalleryOpen={setIsVulcanGalleryOpen}
+          />
         </div>
 
         <section id="services" className="py-24 bg-muted/30 fluid-animate opacity-0 translate-y-[50px]">

--- a/components/wall-systems-showcase.tsx
+++ b/components/wall-systems-showcase.tsx
@@ -311,9 +311,18 @@ const installationImagesData = [
   },
 ];
 
-export function WallSystemsShowcase() {
+export function WallSystemsShowcase({
+  externalIsVulcanGalleryOpen,
+  setExternalIsVulcanGalleryOpen,
+}: {
+  externalIsVulcanGalleryOpen?: boolean
+  setExternalIsVulcanGalleryOpen?: (isOpen: boolean) => void
+} = {}) {
   const [selectedImage, setSelectedImage] = useState(0)
-  const [isVulcanGalleryOpen, setIsVulcanGalleryOpen] = useState(false)
+  const [internalIsVulcanGalleryOpen, setInternalIsVulcanGalleryOpen] = useState(false)
+
+  const isVulcanGalleryOpen = externalIsVulcanGalleryOpen !== undefined ? externalIsVulcanGalleryOpen : internalIsVulcanGalleryOpen
+  const setIsVulcanGalleryOpen = setExternalIsVulcanGalleryOpen || setInternalIsVulcanGalleryOpen
   const [isMiniMattGalleryOpen, setIsMiniMattGalleryOpen] = useState(false)
   const [isFoamRangeGalleryOpen, setIsFoamRangeGalleryOpen] = useState(false)
   const [isSlatWallGalleryOpen, setIsSlatWallGalleryOpen] = useState(false)


### PR DESCRIPTION
The user requested that the "View Vulcan Range" button in the hero section of the main page open the modal containing the Vulcan images. I lifted the state `isVulcanGalleryOpen` from the `WallSystemsShowcase` component up to `app/page.tsx` and modified the hero button's onClick event to trigger this state instead of using an anchor link. The modal continues to work correctly when opened from within the `WallSystemsShowcase` component itself.

---
*PR created automatically by Jules for task [17571170844182461701](https://jules.google.com/task/17571170844182461701) started by @DXeLMedia*