### PR TITLE
Fix Watch Demo button behavior

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -126,16 +126,15 @@ export default function HomePage() {
                   <ArrowRight className="ml-2 h-5 w-5 transition-transform duration-400 group-hover:translate-x-2" />
                 </Button>
               </a>
-              <a href="#demo">
-                <Button
-                  size="lg"
-                  variant="outline"
-                  className="btn-secondary text-lg px-10 py-4 magnetic-hover bg-transparent fluid-animate opacity-0 translate-y-[20px] stagger-6 transition-all duration-400 group"
-                >
-                  <Play className="mr-2 h-5 w-5 transition-transform duration-400 group-hover:scale-125" />
-                  Watch Demo
-                </Button>
-              </a>
+              <Button
+                onClick={() => setVideoModalOpen(true)}
+                size="lg"
+                variant="outline"
+                className="btn-secondary text-lg px-10 py-4 magnetic-hover bg-transparent fluid-animate opacity-0 translate-y-[20px] stagger-6 transition-all duration-400 group"
+              >
+                <Play className="mr-2 h-5 w-5 transition-transform duration-400 group-hover:scale-125" />
+                Watch Demo
+              </Button>
             </div>
           </div>
 


### PR DESCRIPTION
Modified the "Watch Demo" button in the Hero section to directly open the video modal. 
- Removed the wrapping `<a href="#demo">` tag.
- Added `onClick={() => setVideoModalOpen(true)}` to the `<Button>` component to directly trigger the modal state.

---
*PR created automatically by Jules for task [15357793013458727274](https://jules.google.com/task/15357793013458727274) started by @DXeLMedia*