### PR TITLE
Fix typo in contact section Fine Print

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -372,7 +372,7 @@ export default function HomePage() {
                   })}
                   <div className="pl-[4rem] pr-6 py-4 text-xs font-medium whitespace-pre-wrap fluid-animate opacity-0 translate-y-[30px] stagger-3">
                     FINE PRINT:{"\n\n"}
-                    Assessments done via email, phone or WhatsApp are not charged charge, however all information and measurements must be supplied by the customer. Please send us an email or get in touch with us via WhatsApp{"\n\n"}
+                    Assessments done via email, phone or WhatsApp are not charged. However, all information and measurements must be supplied by the customer. Please send us an email or get in touch with us via WhatsApp{"\n\n"}
                     if you require a Specialist or Contractor to come out and assess the room, please fill out the Assessment form below.{"\n\n"}
                     OUR FEE STRUCTURE{"\n"}
                     Assessment Fee: within a 10km radius or less in R500{"\n"}


### PR DESCRIPTION
Updated the Fine Print text in the contact section to read "Assessments done via email, phone or WhatsApp are not charged." instead of "are not charged charge,". This improves readability and fixes a typo.

---
*PR created automatically by Jules for task [7009436567666573129](https://jules.google.com/task/7009436567666573129) started by @DXeLMedia*