### PR TITLE
feat: add D-One video to Install Shorts Gallery

### DIFF
--- a/components/wall-systems-showcase.tsx
+++ b/components/wall-systems-showcase.tsx
@@ -110,6 +110,11 @@ const installShortsVideos = [
     iframeSrc: "https://drive.google.com/file/d/1H6jwb-bIYGSzMfSpXtutAD6hT81Aenr_/preview",
     title: "DSM Install",
   },
+  {
+    id: "d-one",
+    iframeSrc: "https://drive.google.com/file/d/1i0qQR24jFs4rSBhKUEuNCA92zBQDzqD8/preview",
+    title: "D-One",
+  },
 ]
 
 const cloudInstallsImagesRaw = [


### PR DESCRIPTION
Appended the requested "D-One" video to the `installShortsVideos` array, using the `/preview` URL format for proper iframe embedding.